### PR TITLE
add restricted user admin

### DIFF
--- a/backend/api/admin.py
+++ b/backend/api/admin.py
@@ -1,6 +1,51 @@
 from django.contrib import admin
+from django.contrib.auth.models import User
+from django.contrib.auth.admin import UserAdmin
 
 from . import models
+
+
+# https://realpython.com/manage-users-in-django-admin/
+# Unregister the provided model admin
+admin.site.unregister(User)
+
+# Register out own model admin, based on the default UserAdmin
+@admin.register(User)
+class CustomUserAdmin(UserAdmin):
+    readonly_fields = [
+        'date_joined',
+    ]
+
+    def get_form(self, request, obj=None, **kwargs):
+        form = super().get_form(request, obj, **kwargs)
+        is_superuser = request.user.is_superuser
+        disabled_fields = set()
+
+        if not is_superuser:
+            disabled_fields |= {
+                'username',
+                'is_superuser',
+                'user_permissions'
+            }
+
+        # Prevent non-superusers from editing their own permissions
+        if (
+            not is_superuser
+            and obj is not None
+            and obj == request.user
+        ):
+            disabled_fields |= {
+                'is_staff',
+                'is_superuser',
+                'groups',
+                'user_permissions',
+            }
+
+        for f in disabled_fields:
+            if f in form.base_fields:
+                form.base_fields[f].disabled = True
+
+        return form
 
 
 @admin.register(models.EntityType)


### PR DESCRIPTION
closes #25 

omitted the need for a separate role model as we can reuse prefined is_staff and is_superuser flags for roles.
user creation will be done in admin site.